### PR TITLE
FEAT: 회원가입, 로그인,로그아웃 alert->toast/alertDialog 로 구현

### DIFF
--- a/src/components/common/AppHeader.tsx
+++ b/src/components/common/AppHeader.tsx
@@ -17,6 +17,17 @@ import ModalRanking from "./modal/RankingModal";
 import { useLogin, useUser } from "@/store/store";
 import { useRouter } from "next/navigation";
 import LinearProgress from "./LinearProgress";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
 
 // Navigation menu items
 const navItems = [
@@ -45,6 +56,8 @@ function AppHeader({ isSticky }: { isSticky?: boolean }) {
   const { isLogin, toggleLogin } = useLogin();
   const { setUserInfo, deleteUserInfo } = useUser();
 
+  const [showLogoutDialog, setShowLogoutDialog] = useState(false);
+
   const checkLogin = useCallback(async () => {
     const { data } = await handleApi(() => fetchCurrentUser());
     console.log(data);
@@ -56,11 +69,11 @@ function AppHeader({ isSticky }: { isSticky?: boolean }) {
     checkLogin();
   }, []);
 
-  const handleLogout = () => {
+  const executeLogout = () => {
     toggleLogin(false); // 로그인 상태 변경
     deleteUserInfo(); // 사용자 정보 초기화
     handleApi(() => logout());
-    alert("로그아웃 되었습니다.");
+    toast.success("로그아웃 되었습니다.");
     router.push("/"); // 홈으로 리다이렉트
   };
 
@@ -114,7 +127,7 @@ function AppHeader({ isSticky }: { isSticky?: boolean }) {
                 <Button
                   variant="link"
                   className="font-['Julius_Sans_One',Helvetica] text-1xl text-black p-0 cursor-pointer"
-                  onClick={handleLogout}
+                  onClick={() => setShowLogoutDialog(true)}
                 >
                   Logout
                 </Button>
@@ -151,6 +164,20 @@ function AppHeader({ isSticky }: { isSticky?: boolean }) {
           </div>
         </div>
       </header>
+      <AlertDialog open={showLogoutDialog} onOpenChange={setShowLogoutDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>정말 로그아웃 하시겠어요?</AlertDialogTitle>
+            <AlertDialogDescription>
+              로그아웃 시 다시 로그인해야 이용할 수 있어요.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>취소</AlertDialogCancel>
+            <AlertDialogAction onClick={executeLogout}>확인</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
       <LinearProgress colorClassName="bg-[black]" />
     </Fragment>
   );

--- a/src/components/common/modal/LoginModal.tsx
+++ b/src/components/common/modal/LoginModal.tsx
@@ -1,6 +1,5 @@
-'use client'
 "use client";
-import { memo, useCallback, useRef } from "react";
+import { memo, useCallback, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -10,6 +9,17 @@ import { handleApi } from "@/utils/handleApi";
 import { login } from "@/services/login";
 import Image from "next/image";
 import { useLogin } from "@/store/store";
+import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+import { AlertTriangle } from "lucide-react";
 
 function LoginModal({ handleChangeModal }: ModalProps) {
   const emailRef = useRef<HTMLInputElement>(null);
@@ -17,20 +27,21 @@ function LoginModal({ handleChangeModal }: ModalProps) {
 
   const { toggleLogin } = useLogin();
 
+  const [showLoginFailDialog, setShowLoginFailDialog] = useState(false);
+
   const tryLogin = useCallback(async () => {
     const loginInfo = {
       email: emailRef.current?.value,
-      password: passwordRef.current?.value
-    }
+      password: passwordRef.current?.value,
+    };
     const { data } = await handleApi(() => login(loginInfo));
     if (data?.message === "SUCCESS") {
       toggleLogin(true);
-      alert("로그인 성공");
+      toast.success("로그인 성공");
+    } else {
+      setShowLoginFailDialog(true); //진짜 로그아웃 할건지 다이얼로그 오픈
     }
-    else {
-      alert("로그인 실패 ㅅㄱ");
-    }
-  }, [])
+  }, []);
 
   return (
     <div className="flex h-full">
@@ -96,12 +107,30 @@ function LoginModal({ handleChangeModal }: ModalProps) {
             />
           </div>
 
-          <Button className="w-full h-[66px] mt-6 bg-[#222222] hover:bg-black rounded-[10px] text-white text-2xl font-semibold"
-            onClick={tryLogin}>
+          <Button
+            className="w-full h-[66px] mt-6 bg-[#222222] hover:bg-black rounded-[10px] text-white text-2xl font-semibold"
+            onClick={tryLogin}
+          >
             CONTINUE
           </Button>
         </div>
       </div>
+      <AlertDialog open={showLoginFailDialog} onOpenChange={setShowLoginFailDialog}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <div className="flex items-center gap-2">
+              <AlertTriangle className="h-5 w-5 text-red-500" />
+              <AlertDialogTitle>로그인 실패</AlertDialogTitle>
+            </div>
+            <AlertDialogDescription>이메일 또는 비밀번호가 잘못되었습니다.</AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogAction onClick={() => setShowLoginFailDialog(false)}>
+              확인
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/src/components/common/modal/SignupModal.tsx
+++ b/src/components/common/modal/SignupModal.tsx
@@ -8,6 +8,7 @@ import { ModalProps } from "@/types/modal";
 import { handleApi } from "@/utils/handleApi";
 import { checkEmail, joinMembership } from "@/services/join";
 import { joinValues } from "@/types/join";
+import { toast } from "sonner";
 
 function SignupModal({ handleChangeModal }: ModalProps) {
   const emailRef = useRef<HTMLInputElement>(null);
@@ -34,24 +35,22 @@ function SignupModal({ handleChangeModal }: ModalProps) {
     name: nameRef,
     nickname: nicknameRef,
     password: passwordRef,
-    repeatPassword: repeatPasswordRef
-  }
+    repeatPassword: repeatPasswordRef,
+  };
   const emailDuplicateCheck = async () => {
     const data = await handleApi(() => checkEmail(emailRef.current?.value));
     console.log(data);
-    if (typeof (data.data) === "string") {
-      alert("error");
+    if (typeof data.data === "string") {
+      toast.error("error");
       checkRef.current = false;
-    }
-    else if (data.data) {
-      alert("사용 가능한 ID 입니다.");
+    } else if (data.data) {
+      toast.success("사용 가능한 ID 입니다.");
       checkRef.current = true;
-    }
-    else {
-      alert("이미 존재하는 ID 입니다.");
+    } else {
+      toast.warning("이미 존재하는 ID 입니다.");
       checkRef.current = false;
     }
-  }
+  };
 
   const join = useCallback(async () => {
     const joinInfo: joinValues = {
@@ -59,23 +58,22 @@ function SignupModal({ handleChangeModal }: ModalProps) {
       real_name: nameRef.current?.value,
       nickname: nicknameRef.current?.value,
       password: passwordRef.current?.value,
-    }
+    };
     if (!checkRef.current) {
-      alert("ID 중복 확인을 해주세요");
+      toast.warning("ID 중복 확인을 해주세요");
       return;
     }
     if (passwordRef.current?.value !== repeatPasswordRef.current?.value) {
-      alert("비밀번호가 알맞지 않습니다.")
+      toast.warning("비밀번호가 일치하지 않습니다.");
       return;
     }
     const data = await handleApi(() => joinMembership(joinInfo));
 
     if (data.data === "회원가입 성공!") {
-      alert("회원가입 되었습니다. 로그인을 진행해 주세요");
+      toast.success("회원가입 되었습니다. 로그인을 진행해 주세요");
       handleChangeModal();
-    }
-    else alert("회원가입 도중 에러가 발생했습니다.");
-  }, [])
+    } else toast.error("회원가입 도중 에러가 발생했습니다.");
+  }, []);
 
   return (
     <div className="flex h-full">
@@ -148,8 +146,10 @@ function SignupModal({ handleChangeModal }: ModalProps) {
           ))}
 
           {/* Submit button */}
-          <Button className="w-full h-[66px] bg-[#222222] hover:bg-[#333333] rounded-[10px] text-white text-2xl font-semibold"
-            onClick={join}>
+          <Button
+            className="w-full h-[66px] bg-[#222222] hover:bg-[#333333] rounded-[10px] text-white text-2xl font-semibold"
+            onClick={join}
+          >
             Create Account
           </Button>
         </div>


### PR DESCRIPTION
## #️⃣연관된 이슈
#40 

## 📝작업 내용
1. 회원가입시 관련 alert 를 toast 로 변경.
2. 로그인 성공시 toast로 알람.
3. 로그인 실패시 alertDialog로 알람.
4. 로그아웃시 alertDialog/toast 로 알람.

## 스크린샷
|회원가입 toast|로그아웃시 알람|
|---|---|
|<img width="716" alt="image" src="https://github.com/user-attachments/assets/536ac4d7-8c53-4044-87a4-849c8b42ab73" />|<img width="716" alt="image" src="https://github.com/user-attachments/assets/0b15d11d-ca83-4cc6-83a9-eda1679aa7b0" />|

|로그인 성공|로그인 실패|
|---|---|
|<img width="716" alt="image" src="https://github.com/user-attachments/assets/b4dfccc5-5e93-4c9e-9bb0-17aee4ef05cf" />|<img width="716" alt="image" src="https://github.com/user-attachments/assets/7f0e4327-0e60-493e-a2a9-d1b3592cd959" />|

## 추가
아직 다 구현한건 아니지만 일단 스타일 코드 넣어두면 다른 사람이 적용하기 편할 거 같아서 구현한거 추가하겠습니닷
