### PR TITLE
Feature/87/UI 디테일 페이지에서 tap별로 스타일 수정

### DIFF
--- a/src/components/common/board/BidListItem.tsx
+++ b/src/components/common/board/BidListItem.tsx
@@ -1,5 +1,6 @@
-import { Card } from "@/components/ui/card";
+import { Card, CardHeader } from "@/components/ui/card";
 import { DialogReport } from "@/components/ui/dialogReport";
+import { Separator } from "@/components/ui/separator";
 // import { Separator } from "@/components/ui/separator";
 import { BidMessage } from "@/types/bid";
 import React, { memo } from "react";
@@ -12,22 +13,35 @@ const BidListItem = ({ bid, postId }: BidListProps) => {
   const { bid_price, content, created_at, user_id } = bid;
   console.log("userid", user_id);
   return (
-    <Card className="relative py-2 px-4 border-none shadow-lg mb-2">
-      <div className="py-[15px]">
-        <div className="flex flex-row justify-between">
-          <p className="[font-family:'Noto_Sans_KR-Regular',Helvetica] font-normal text-black text-[4vw] sm:text-base lg:text-xl">
-            입찰가 : {bid_price}
-          </p>
+    <Card className="border-none bg-[#faf8ef] rounded-lg m-3 px-1 py-3">
+      <CardHeader className="flex flex-col gap-1">
+        <div className="w-full flex justify-between items-center">
+          {/* 입찰가 */}
+          <div className="flex flex-col mb-2">
+            <span className="text-sm text-gray-500">입찰가</span>
+            <span className="text-xl font-bold text-black">{bid_price.toLocaleString()}원</span>
+          </div>
+          {/* 신고 버튼 */}
           <DialogReport postId={postId} reportedUserId={user_id} />
         </div>
-        <p className="[font-family:'Noto_Sans_KR-Regular',Helvetica] font-normal text-black text-[4vw] sm:text-base lg:text-xl">
-          <br />
+        <Separator className="bg-gray-200" />
+
+        {/* 입찰 내용 */}
+        <div className="text-m rounded-md py-1 font-semibold leading-relaxed whitespace-pre-wrap">
           {content}
-          <br />
-        </p>
-        <p className="[font-family:'Noto_Sans_KR-Regular',Helvetica] font-normal text-gray-300 text-[3vw] sm:text-base lg:text-xl text-right">
-          {new Date(created_at).toLocaleString()}
-        </p>
+        </div>
+      </CardHeader>
+
+      {/* Separator가 필요하면 아래 주석 해제 */}
+      {/* 작성 시간 */}
+      <div className="text-xs text-muted-foreground text-end px-6 text-gray-500">
+        {new Date(created_at).toLocaleString("ko-KR", {
+          year: "numeric",
+          month: "2-digit",
+          day: "2-digit",
+          hour: "2-digit",
+          minute: "2-digit",
+        })}
       </div>
     </Card>
   );

--- a/src/components/common/board/ItemInfoTabs.tsx
+++ b/src/components/common/board/ItemInfoTabs.tsx
@@ -3,6 +3,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { BidMessage } from "@/types/bid";
 import BidListItem from "./BidListItem";
 import QnaList from "@/components/common/board/Qna/QnaList";
+import { Separator } from "@/components/ui/separator";
 
 interface ItemInfoTabsProps {
   postId: number;
@@ -17,22 +18,22 @@ const ItemInfoTabs = ({ data, bids, postId, userId }: ItemInfoTabsProps): JSX.El
   console.log("lololololo", data.content, bids);
   return (
     <div className="mt-[8vh] w-[90vw] max-w-[600px] mx-auto xl:ml-[18vw] xl:mx-0">
-      <Tabs defaultValue="bidHistory">
+      <Tabs defaultValue="bidHistory" className="mb-4">
         <TabsList className="bg-transparent p-0 h-auto flex gap-x-8">
           {["productDescription", "bidHistory", "qna"].map((key, idx) => (
             <TabsTrigger
               key={key}
               value={key}
-              className="[font-family:'Noto_Sans_KR-Bold',Helvetica] font-bold text-[#b6b6b6] text-[5vw] sm:text-[24px] lg:text-[28px] data-[state=active]:text-black data-[state=active]:rounded-none data-[state=active]:shadow-none px-0 pb-2"
+              className="cursor-pointer hover:text-gray-600 [font-family:'Noto_Sans_KR-Bold',Helvetica] font-bold text-[#b6b6b6] text-[5vw] sm:text-[24px] lg:text-[28px] data-[state=active]:text-black data-[state=active]:rounded-none data-[state=active]:shadow-none px-0 pb-2"
             >
               {["제품 설명", "입찰 내역", "QnA"][idx]}
             </TabsTrigger>
           ))}
         </TabsList>
-
+        <Separator className="bg-gray-300" />
         <TabsContent value="productDescription" className="mt-0">
           <div
-            className="[&>h1]:text-3xl [&>h2]:text-2xl [&>h3]:text-xl min-h-50 p-2 pt-10"
+            className="p-3 bg-[#faf8ef] rounded-lg shadow-sm min-h-[200px] mt-2 mb-8"
             dangerouslySetInnerHTML={{ __html: data.content ?? "<p>등록 내용 없음</p>" }}
           />
         </TabsContent>

--- a/src/components/common/board/Qna/QnaItem.tsx
+++ b/src/components/common/board/Qna/QnaItem.tsx
@@ -35,7 +35,7 @@ export default function QnaItem({ qna, isOwner, postId, onSuccess }: QnaItemProp
         {qna.answer_content ? (
           <div className="flex items-start gap-1 mb-2">
             {/* A. 고정 접두어 */}
-            <span className="font-bold pt-[0.5px]">A.</span>
+            <span className="font-bold pt-[3px]">A.</span>
 
             {/* 답변 박스 */}
             <div className="text-sm rounded-md py-1 px-2 bg-[#efede3]/80 font-semibold leading-relaxed">

--- a/src/components/ui/dialogReport.tsx
+++ b/src/components/ui/dialogReport.tsx
@@ -61,7 +61,7 @@ export function DialogReport({ postId, reportedUserId }: DialogRepoerProps) {
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button variant="ghost">
+        <Button variant="ghost" className="text-red-500 hover:bg-[#f8e9d7] cursor-pointer">
           <AlertTriangle className="text-red-500" />
         </Button>
       </DialogTrigger>


### PR DESCRIPTION
## #️⃣연관된 이슈
#87 

## 📝작업 내용
디테일 페이지 자잘하게 수정
1. 제품 설명 카드 디자인 수정.
2. 입찰 내역 카드 디자인 수정.
3. tab바 반응형으로 스타일 추가.
4. QnA 답변 위치 수정.

## 스크린샷
| 제품 설명 카드 디자인 수정 | 입찰 내역 카드 디자인 수정 |
| -- | -- |
| <img width="624" alt="image" src="https://github.com/user-attachments/assets/dab19cb5-2909-4b02-87f2-ccb8d7407aae" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/8da4aa68-845b-4888-b861-5340a2a207bc" /> <img width="300" alt="image" src="https://github.com/user-attachments/assets/948b4722-9add-4a8f-a63d-a47753cd70d8" /> |

| tab바 반응형으로 스타일 추가 | QnA 답변 위치 수정 |
| -- | -- |
| <img width="624" alt="image" src="https://github.com/user-attachments/assets/e659405a-b2a2-4cfd-a9d6-50bf1ff1191e" /> | <img width="231" alt="image" src="https://github.com/user-attachments/assets/b1389e8b-ffd8-451c-aa42-afbd8d576827" /> |
||A의 위치를 조금 아래로 내린 것임!|